### PR TITLE
make inline break work

### DIFF
--- a/lib/asciidoctor-mallard/converter.rb
+++ b/lib/asciidoctor-mallard/converter.rb
@@ -352,7 +352,7 @@ module Mallard
     alias :inline_callout :skip
 
     def inline_break node
-      %(#{node.text}<?asciidoc-br?>)
+      %(#{node.text}<br xmlns="http://www.w3.org/ns/ttml"/>)
     end
 
     def inline_footnote node

--- a/test/examples/mallard/block_page_break.page
+++ b/test/examples/mallard/block_page_break.page
@@ -1,4 +1,4 @@
 <!-- .basic -->
 <p>Text on the first page</p>
-<p><?asciidoc-pagebreak></p>
+<p><?asciidoc-pagebreak?></p>
   <p>was breaked!</p>

--- a/test/examples/mallard/block_thematic_break.page
+++ b/test/examples/mallard/block_thematic_break.page
@@ -1,2 +1,2 @@
 <!-- .basic -->
-<p><?asciidoc-hr></p>
+<p><?asciidoc-hr?></p>

--- a/test/examples/mallard/inline_break.page
+++ b/test/examples/mallard/inline_break.page
@@ -1,5 +1,7 @@
 <!-- .plus_sign -->
-Rubies are red,<?asciidoc-br> Topazes are blue.
+Rubies are red,<br xmlns="http://www.w3.org/ns/ttml"/>
+Topazes are blue.
 
 <!-- .hardbreaks -->
-Ruby is red.<?asciidoc-br> Java is black.
+Ruby is red.<br xmlns="http://www.w3.org/ns/ttml"/>
+Java is black.


### PR DESCRIPTION
- use `<br xmlns="http://www.w3.org/ns/ttml"/>` (works in Yelp)
- update inline_break test
- fix test for block_page_break
- fix test for block_thematic_break
