### PR TITLE
Allow Mallard links to be provided in an AsciiDoc attribute

### DIFF
--- a/lib/asciidoctor-mallard/converter.rb
+++ b/lib/asciidoctor-mallard/converter.rb
@@ -527,9 +527,9 @@ module Mallard
           end
           if typeg.include? '/'
             type, group = typeg.split('/')
-            result << %(<link type="#{type}" group="#{group}" xref="#{xref}"/>)
+            result << %(<link type="#{type}" group="#{group}" xref="#{xref.strip}"/>)
           else
-            result << %(<link type="#{typeg}" xref="#{xref}"/>)
+            result << %(<link type="#{typeg}" xref="#{xref.strip}"/>)
           end
         end
       end

--- a/lib/asciidoctor-mallard/converter.rb
+++ b/lib/asciidoctor-mallard/converter.rb
@@ -517,6 +517,22 @@ module Mallard
       #else
       #  result << %(<revision date="#{(doc.attr? 'revdate') ? (doc.attr 'revdate') : (doc.attr 'docdate')}"/>)
       end
+      if doc.attr? 'mallard-links'
+        (doc.attr 'mallard-links').each_line(' ') do |link|
+          if link.include? ':'
+            typeg, xref = link.split(':')
+          else
+            typeg = 'guide'
+            xref = link
+          end
+          if typeg.include? '/'
+            type, group = typeg.split('/')
+            result << %(<link type="#{type}" group="#{group}" xref="#{xref}"/>)
+          else
+            result << %(<link type="#{typeg}" xref="#{xref}"/>)
+          end
+        end
+      end
       unless result.empty?
         result.unshift '<info>'
         result << '</info>'


### PR DESCRIPTION
Info links are an integral part of how Mallard works. This allows you
to specify info links as a space-separated list of tokens using the
'mallard-links' attribute in AsciiDoc. Each token specifies one link,
and is of the general form:

```
type/group:xref
```

This produces:

```
<link type="type" group="group" xref="xref"/>
```

Groups are optional. If no type is specified, 'guide' is assumed.
